### PR TITLE
Wiring between DMA(KF8237) and floppy device.

### DIFF
--- a/rtl/KFPC-XT/HDL/Chipset.sv
+++ b/rtl/KFPC-XT/HDL/Chipset.sv
@@ -105,6 +105,8 @@ module CHIPSET (
     logic           data_bus_out_from_chipset;
     logic           internal_data_bus_direction;
 
+    logic           dma_floppy_req;
+
     READY u_READY (
         .clock                              (clock),
         .reset                              (reset),
@@ -151,7 +153,7 @@ module CHIPSET (
         .memory_write_n                     (memory_write_n),
         .memory_write_n_ext                 (memory_write_n_ext),
         .memory_write_n_direction           (memory_write_n_direction),
-        .dma_request                        (dma_request),
+        .dma_request                        ({dma_request[3], dma_floppy_req, dma_request[1:0]}),
         .dma_acknowledge_n                  (dma_acknowledge_n),
         .address_enable_n                   (address_enable_n),
         .terminal_count_n                   (terminal_count_n)
@@ -184,6 +186,7 @@ module CHIPSET (
         .memory_read_n                      (memory_read_n),
         .memory_write_n                     (memory_write_n),
         .address_enable_n                   (address_enable_n),
+        .terminal_count_n                   (terminal_count_n),
 		  
 		  .mgmt_address                       (mgmt_address),
 	     .mgmt_write                         (mgmt_write),
@@ -191,6 +194,8 @@ module CHIPSET (
 		  .clock_rate                         (clock_rate),
 		  .floppy_wp                          (floppy_wp),
 		  .fdd_request                        (fdd_request),
+        .dma_floppy_req                     (dma_floppy_req),
+        .dma_floppy_ack                     (~dma_acknowledge_n[2]),
 		  
         .timer_counter_out                  (timer_counter_out),
         .speaker_out                        (speaker_out),

--- a/rtl/KFPC-XT/HDL/Peripherals.sv
+++ b/rtl/KFPC-XT/HDL/Peripherals.sv
@@ -331,10 +331,10 @@ floppy floppy
 	.clock_rate        (clock_rate),
 
 	.io_address        (address[2:0]),
-	.io_writedata      (fdd_cpu_dout),
+	.io_writedata      (internal_data_bus),
 	.io_read           (~io_read_n & ~floppy0_select_n),
 	.io_write          (~io_write_n & ~floppy0_select_n),
-	.io_readdata       (internal_data_bus),
+	.io_readdata       (fdd_cpu_dout),
 	
 //	.fdd0_inserted     (fdd0_inserted),
 


### PR DESCRIPTION
Wiring when using fdd devices with DMA transfers.
I am not familiar with this device and this pull request alone may not work correctly.