### PR TITLE
Step1. PS/2 CLK to drop LOW after receiving the key code.

### DIFF
--- a/PCXT.sv
+++ b/PCXT.sv
@@ -244,6 +244,7 @@ wire[ 0:0] usdImgMtd;
 //wire        ps2_kbd_data_out;
 wire        ps2_kbd_clk_in;
 wire        ps2_kbd_data_in;
+wire        ps2_kbd_busy;
 
 //Mouse PS2
 wire        ps2_mouse_clk_out;
@@ -287,7 +288,7 @@ hps_io #(.CONF_STR(CONF_STR), .PS2DIV(2000), .PS2WE(1)) hps_io
 	.img_mounted   (usdImgMtd),
 	.img_size	   (usdImgSz),	
 	
-   .ps2_kbd_clk_in	(1'b1),
+   .ps2_kbd_clk_in	(~ps2_kbd_busy),
 	.ps2_kbd_data_in	(1'b1),
 	.ps2_kbd_clk_out	(ps2_kbd_clk_in),
 	.ps2_kbd_data_out	(ps2_kbd_data_in),
@@ -516,6 +517,7 @@ always @(posedge clk_4_77)
 	     .speaker_out                        (speaker_out),   
         .ps2_clock                          (ps2_kbd_clk_in),
 	     .ps2_data                           (ps2_kbd_data_in),
+	     .ps2_busy                           (ps2_kbd_busy),
 	     .enable_sdram                       (0),	   // -> During the first tests, it shall not be used.		  
 		  .clk_en_opl2                        (cen_opl2), // clk_en_opl2
 		  .jtopl2_snd_e                       (jtopl2_snd_e),

--- a/rtl/KFPC-XT/HDL/Chipset.sv
+++ b/rtl/KFPC-XT/HDL/Chipset.sv
@@ -66,6 +66,7 @@ module CHIPSET (
     output  logic   [7:0]   port_c_io,
     input   logic           ps2_clock,
     input   logic           ps2_data,
+    output  logic           ps2_busy,
 	 // JTOPL	 
 	 input   logic           clk_en_opl2,
 	 output  logic   [15:0]  jtopl2_snd_e,
@@ -211,6 +212,7 @@ module CHIPSET (
         .port_c_io                          (port_c_io),
         .ps2_clock                          (ps2_clock),
         .ps2_data                           (ps2_data),
+	.ps2_busy                           (ps2_busy),
 		  .clk_en_opl2                        (clk_en_opl2),
 		  .jtopl2_snd_e                       (jtopl2_snd_e),
 		  .adlibhide                          (adlibhide),

--- a/rtl/KFPC-XT/HDL/Peripherals.sv
+++ b/rtl/KFPC-XT/HDL/Peripherals.sv
@@ -50,6 +50,7 @@ module PERIPHERALS #(
     output  logic   [7:0]   port_c_io,
     input   logic           ps2_clock,
     input   logic           ps2_data,
+    output  logic           ps2_busy,
 	 // JTOPL	 
 	 input   logic           clk_en_opl2,
 	 output  logic   [15:0]  jtopl2_snd_e,
@@ -264,6 +265,7 @@ module PERIPHERALS #(
         .keycode                    (keycode),
         .clear_keycode              (clear_keycode)
     );
+    assign ps2_busy = keybord_irq;
 
    wire [7:0] jtopl2_dout;
 	wire [7:0]opl32_data;	


### PR DESCRIPTION
I can confirm that now there is never a problem with the keyboard when starting the OS, thank you very much, I add it to the master branch. This doesn't solve the games where the keyboard doesn't work, but it is very useful to have the keyboard always available from OS startup.