### PR TITLE
Fixed problem with INT0 test failing.

### DIFF
--- a/rtl/KFPC-XT/HDL/KF8253/HDL/KF8253_Counter.sv
+++ b/rtl/KFPC-XT/HDL/KF8253/HDL/KF8253_Counter.sv
@@ -32,7 +32,6 @@ module KF8253_Counter (
     logic           update_select_read_write;
     logic           count_latched_flag;
     logic   [2:0]   select_mode;
-    logic           update_select_mode;
     logic           select_bcd;
 
     logic           write_count_step;
@@ -117,8 +116,6 @@ module KF8253_Counter (
         else
             select_mode <= select_mode;
     end
-
-    assign update_select_mode = (select_mode != internal_data_bus[3:1]) & update_counter_config;
 
     // BCD
     always_ff @(negedge clock, posedge reset) begin
@@ -245,7 +242,7 @@ module KF8253_Counter (
     always_ff @(negedge clock, posedge reset) begin
         if (reset)
             start_counting <= 1'b0;
-        else if (update_select_mode)
+        else if (update_counter_config)
             start_counting <= 1'b0;
         else if (write_counter) begin
             if (select_read_write != `RL_SELECT_LSB_MSB)

--- a/rtl/KFPC-XT/HDL/KF8259/HDL/KF8259.sv
+++ b/rtl/KFPC-XT/HDL/KF8259/HDL/KF8259.sv
@@ -145,6 +145,7 @@ module KF8259 (
         .level_or_edge_toriggered_config    (level_or_edge_toriggered_config),
         .freeze                             (freeze),
         .clear_interrupt_request            (clear_interrupt_request),
+        .interrupt_mask                     (interrupt_mask),
 
         // External inputs
         .interrupt_request_pin              (interrupt_request),

--- a/rtl/KFPC-XT/HDL/KF8259/HDL/KF8259_Interrupt_Request.sv
+++ b/rtl/KFPC-XT/HDL/KF8259/HDL/KF8259_Interrupt_Request.sv
@@ -11,6 +11,7 @@ module KF8259_Interrupt_Request (
     input   logic           level_or_edge_toriggered_config,
     input   logic           freeze,
     input   logic   [7:0]   clear_interrupt_request,
+    input   logic   [7:0]   interrupt_mask,
 
     // External inputs
     input   logic   [7:0]   interrupt_request_pin,
@@ -47,6 +48,8 @@ module KF8259_Interrupt_Request (
                 interrupt_request_register[ir_bit_no] <= 1'b0;
             else if (freeze)
                 interrupt_request_register[ir_bit_no] <= interrupt_request_register[ir_bit_no];
+            else if (interrupt_mask[ir_bit_no])
+                interrupt_request_register[ir_bit_no] <= 1'b0;
             else if (interrupt_request_register[ir_bit_no])
                 interrupt_request_register[ir_bit_no] <= 1'b1;
             else if (level_or_edge_toriggered_config)


### PR DESCRIPTION
1. Changed to stop and clear the counter when writing a control word
2. Changed to ignore masked interrupt input.