### PR TITLE
Fix keybord lock

### DIFF
--- a/rtl/KFPC-XT/HDL/KF8259/HDL/KF8259.sv
+++ b/rtl/KFPC-XT/HDL/KF8259/HDL/KF8259.sv
@@ -145,7 +145,6 @@ module KF8259 (
         .level_or_edge_toriggered_config    (level_or_edge_toriggered_config),
         .freeze                             (freeze),
         .clear_interrupt_request            (clear_interrupt_request),
-        .interrupt_mask                     (interrupt_mask),
 
         // External inputs
         .interrupt_request_pin              (interrupt_request),

--- a/rtl/KFPC-XT/HDL/KF8259/HDL/KF8259_Control_Logic.sv
+++ b/rtl/KFPC-XT/HDL/KF8259/HDL/KF8259_Control_Logic.sv
@@ -537,9 +537,7 @@ module KF8259_Control_Logic (
             interrupt_to_cpu <= 1'b0;
         else if (interrupt != 8'b00000000)
             interrupt_to_cpu <= 1'b1;
-        else if (end_of_acknowledge_sequence == 1'b1)
-            interrupt_to_cpu <= 1'b0;
-        else if (end_of_poll_command == 1'b1)
+        else if (next_control_state == CTL_READY)
             interrupt_to_cpu <= 1'b0;
         else
             interrupt_to_cpu <= interrupt_to_cpu;


### PR DESCRIPTION
Bug fixes for KF8259 have been made. This will no longer cause an interrupt deadlock in 8088bios.