### PR TITLE
Update PCXT.sdc.

### DIFF
--- a/PCXT.sdc
+++ b/PCXT.sdc
@@ -2,7 +2,8 @@ derive_pll_clocks
 derive_clock_uncertainty
 
 # core specific constraints
-set_input_delay -clock { FPGA_CLK2_50 } -max 6 [get_ports { SDRAM_DQ[*] }]
-set_input_delay -clock { FPGA_CLK2_50 } -min 3 [get_ports { SDRAM_DQ[*] }]
-set_output_delay -clock { FPGA_CLK2_50 } -max 2 [get_ports { SDRAM_DQ[*] SDRAM_DQM* SDRAM_A[*] SDRAM_n*  SDRAM_BA SDRAM_CLK }]
-set_output_delay -clock { FPGA_CLK2_50 } -min 0 [get_ports { SDRAM_DQ[*] SDRAM_DQM* SDRAM_A[*] SDRAM_n*  SDRAM_BA SDRAM_CLK }]
+create_generated_clock -name SDRAM_CLK -source { FPGA_CLK2_50 }  [get_ports { SDRAM_CLK }]
+set_input_delay -clock { SDRAM_CLK } -max 6 [get_ports { SDRAM_DQ[*] }]
+set_input_delay -clock { SDRAM_CLK } -min 3 [get_ports { SDRAM_DQ[*] }]
+set_output_delay -clock { SDRAM_CLK } -max 2 [get_ports { SDRAM_DQ[*] SDRAM_DQM* SDRAM_A[*] SDRAM_n*  SDRAM_BA SDRAM_CKE }]
+set_output_delay -clock { SDRAM_CLK } -min 1.5 [get_ports { SDRAM_DQ[*] SDRAM_DQM* SDRAM_A[*] SDRAM_n*  SDRAM_BA SDRAM_CKE }]


### PR DESCRIPTION
Added SDRAM_CLK output pin to SDC file.
This change has eliminated the unstable behavior in my environment.