### PR TITLE
Fix keybord lock

### DIFF
--- a/rtl/KFPC-XT/HDL/KF8259/HDL/KF8259.sv
+++ b/rtl/KFPC-XT/HDL/KF8259/HDL/KF8259.sv
@@ -145,7 +145,6 @@ module KF8259 (
         .level_or_edge_toriggered_config    (level_or_edge_toriggered_config),
         .freeze                             (freeze),
         .clear_interrupt_request            (clear_interrupt_request),
-        .interrupt_mask                     (interrupt_mask),
 
         // External inputs
         .interrupt_request_pin              (interrupt_request),

--- a/rtl/KFPC-XT/HDL/KF8259/HDL/KF8259_Control_Logic.sv
+++ b/rtl/KFPC-XT/HDL/KF8259/HDL/KF8259_Control_Logic.sv
@@ -537,7 +537,9 @@ module KF8259_Control_Logic (
             interrupt_to_cpu <= 1'b0;
         else if (interrupt != 8'b00000000)
             interrupt_to_cpu <= 1'b1;
-        else if (next_control_state == CTL_READY)
+        else if (end_of_acknowledge_sequence == 1'b1)
+            interrupt_to_cpu <= 1'b0;
+        else if (end_of_poll_command == 1'b1)
             interrupt_to_cpu <= 1'b0;
         else
             interrupt_to_cpu <= interrupt_to_cpu;

--- a/rtl/KFPC-XT/HDL/KF8259/HDL/KF8259_Control_Logic.sv
+++ b/rtl/KFPC-XT/HDL/KF8259/HDL/KF8259_Control_Logic.sv
@@ -537,9 +537,7 @@ module KF8259_Control_Logic (
             interrupt_to_cpu <= 1'b0;
         else if (interrupt != 8'b00000000)
             interrupt_to_cpu <= 1'b1;
-        else if (end_of_acknowledge_sequence == 1'b1)
-            interrupt_to_cpu <= 1'b0;
-        else if (end_of_poll_command == 1'b1)
+        else if (next_control_state == CTL_READY)
             interrupt_to_cpu <= 1'b0;
         else
             interrupt_to_cpu <= interrupt_to_cpu;

--- a/rtl/KFPC-XT/HDL/KF8259/HDL/KF8259_Interrupt_Request.sv
+++ b/rtl/KFPC-XT/HDL/KF8259/HDL/KF8259_Interrupt_Request.sv
@@ -51,8 +51,6 @@ module KF8259_Interrupt_Request (
                 interrupt_request_register[ir_bit_no] <= 1'b0;
             else if (freeze)
                 interrupt_request_register[ir_bit_no] <= interrupt_request_register[ir_bit_no];
-            else if (interrupt_request_register[ir_bit_no])
-                interrupt_request_register[ir_bit_no] <= 1'b1;
             else if (level_or_edge_toriggered_config)
                 interrupt_request_register[ir_bit_no] <= interrupt_request_pin[ir_bit_no];
             else


### PR DESCRIPTION
Fixed a problem with 8088 BIOS that would no longer accept keyboard input.
It also passes the diagnostic  test.

However, in my environment, the keyboard sometimes becomes unstable immediately after power-on.
To resolve this, I think we need to write timing constraints.