### PR TITLE
Changed sound module clock to 100 MHz

### DIFF
--- a/PCXT.sv
+++ b/PCXT.sv
@@ -323,7 +323,7 @@ reg clk_14_318 = 1'b0;
 //reg clk_7_16 = 1'b0;
 wire clk_4_77;
 wire clk_cpu;
-wire cen_opl2;
+wire clk_opl2;
 wire peripheral_clock;
 
 pll pll
@@ -333,7 +333,7 @@ pll pll
 	.outclk_0(clk_100),
 	.outclk_1(clk_28_636),	
 	.outclk_2(clk_uart),
-	.outclk_3(cen_opl2),
+	.outclk_3(clk_opl2),
 	.outclk_4(clk_56_875),
 	.locked(pll_locked)
 );
@@ -377,6 +377,19 @@ always @(posedge clk_100) begin
     clk_cpu_ff_2 <= clk_cpu_ff_1;
     clk_cpu      <= clk_cpu_ff_2;
 end
+
+logic   clk_opl2_ff_1;
+logic   clk_opl2_ff_2;
+logic   clk_opl2_ff_3;
+logic   cen_opl2;
+
+always @(posedge clk_100) begin
+    clk_opl2_ff_1 <= clk_opl2;
+    clk_opl2_ff_2 <= clk_opl2_ff_1;
+    clk_opl2_ff_3 <= clk_opl2_ff_2;
+    cen_opl2 <= clk_opl2_ff_2 & ~clk_opl2_ff_3;
+end
+
 
 //////////////////////////////////////////////////////////////////
 

--- a/rtl/KFPC-XT/HDL/Chipset.sv
+++ b/rtl/KFPC-XT/HDL/Chipset.sv
@@ -197,7 +197,6 @@ module CHIPSET (
 		  .clk_sys                            (clk_sys),
 		  .clk_uart                           (clk_uart),
         .peripheral_clock                   (peripheral_clock),
-		  .cpu_clock                          (cpu_clock),
         .reset                              (reset),
         .interrupt_to_cpu                   (interrupt_to_cpu),
         .interrupt_acknowledge_n            (interrupt_acknowledge_n),

--- a/rtl/KFPC-XT/HDL/Peripherals.sv
+++ b/rtl/KFPC-XT/HDL/Peripherals.sv
@@ -8,7 +8,6 @@ module PERIPHERALS #(
     input   logic           clock,
 	 input   logic           clk_sys,
     input   logic           peripheral_clock,
-	 input   logic           cpu_clock,
     input   logic           reset,
     // CPU
     output  logic           interrupt_to_cpu,
@@ -332,7 +331,7 @@ module PERIPHERALS #(
 	jtopl2 jtopl2_inst
 	(
 		.rst(reset),
-		.clk(cpu_clock),
+		.clk(clock),
 		.cen(clk_en_opl2),
 		.din(internal_data_bus),
 		.dout(jtopl2_dout),
@@ -349,7 +348,7 @@ module PERIPHERALS #(
 	// Tandy sound
 	sn76489_top sn76489
 	(
-		.clock_i(cpu_clock),
+		.clock_i(clock),
 		.clock_en_i(clk_en_opl2), // 3.579MHz
 		.res_n_i(~reset),
 		.ce_n_i(tandy_chip_select_n),


### PR DESCRIPTION
Change the clock to the sound module to 100 MHz, the same as other devices.
Keep the same timing as before by using the cen_opl2 signal.