### PR TITLE
In tandy mode, the keyboard reset signal is not used.

### DIFF
--- a/PCXT.sv
+++ b/PCXT.sv
@@ -658,8 +658,8 @@ end
         .sdram_ldqm                         (SDRAM_DQML),
         .sdram_udqm                         (SDRAM_DQMH),
 		  .ems_enabled                        (~status[11]),
-		  .ems_address                        (status[13:12])
-    
+		  .ems_address                        (status[13:12]),
+        .tandy_mode                         (tandy_mode)
     );
 	
 	wire speaker_out;

--- a/rtl/KFPC-XT/HDL/Chipset.sv
+++ b/rtl/KFPC-XT/HDL/Chipset.sv
@@ -114,7 +114,9 @@ module CHIPSET (
     output  logic           sdram_udqm,
 	 // EMS
 	 input   logic           ems_enabled,
-	 input   logic   [1:0]   ems_address
+	 input   logic   [1:0]   ems_address,
+    // Mode Switch
+    input   logic           tandy_mode
 );
 
     logic           dma_ready;
@@ -288,8 +290,8 @@ module CHIPSET (
 	     .ems_b1                            (ems_b1),
 	     .ems_b2                            (ems_b2),
 	     .ems_b3                            (ems_b3),
-	     .ems_b4                            (ems_b4)
-		  
+	     .ems_b4                            (ems_b4),
+        .tandy_mode                         (tandy_mode)
     );
 
     RAM u_RAM (

--- a/rtl/KFPC-XT/HDL/Peripherals.sv
+++ b/rtl/KFPC-XT/HDL/Peripherals.sv
@@ -87,9 +87,9 @@ module PERIPHERALS #(
 	 output  logic           ems_b1,
 	 output  logic           ems_b2,
 	 output  logic           ems_b3,
-	 output  logic           ems_b4
-
-	 
+	 output  logic           ems_b4,
+     // Mode Switch
+    input   logic           tandy_mode
 );
     //
     // chip select
@@ -277,7 +277,7 @@ module PERIPHERALS #(
     logic           lock_recv_clock;
 
     wire    clear_keycode = port_b_out[7];
-    wire    ps2_reset_n   = port_b_out[6];
+    wire    ps2_reset_n   = ~tandy_mode ? port_b_out[6] : 1'b1;
 
     always_ff @(posedge clock, posedge reset) begin
         if (reset)


### PR DESCRIPTION
If video output is set to tandy, the keyboard can be used with tandy bios.
